### PR TITLE
Fix check for correct tool

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -1,7 +1,7 @@
 require("globals")
 
 local function replace_rails(event, entity_mapping)
-	if not event.item == "naked-rails-tool" then
+	if event.item ~= "naked-rails-tool" then
 		return
 	end
 


### PR DESCRIPTION
The `not` applied to `event.item` first, which evaluates to true, which then coerces the string to true.